### PR TITLE
feat: Introduce SentryError type

### DIFF
--- a/demae/error.go
+++ b/demae/error.go
@@ -1,11 +1,12 @@
 package demae
 
 type SentryError struct {
-	s string
+	s      string
+	Report bool
 }
 
-func NewSentryError(s string) error {
-	return &SentryError{s: s}
+func NewSentryError(s string, report bool) error {
+	return &SentryError{s: s, Report: report}
 }
 
 func (s *SentryError) Error() string {

--- a/demae/error.go
+++ b/demae/error.go
@@ -1,0 +1,13 @@
+package demae
+
+type SentryError struct {
+	s string
+}
+
+func NewSentryError(s string) error {
+	return &SentryError{s: s}
+}
+
+func (s *SentryError) Error() string {
+	return s.s
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/WiiLink24/DemaeJustEat
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/WiiLink24/nwc24 v0.0.0-20251223184323-cc2586e6b86d

--- a/justeat/errors.go
+++ b/justeat/errors.go
@@ -5,6 +5,6 @@ import (
 )
 
 var (
-	ErrNotLinked      = demae.NewSentryError("Please link your Just Eat Account with\nyour WiiLink Account")
-	ErrInvalidCountry = demae.NewSentryError("Your Wii's country does not support\nJust Eat")
+	ErrNotLinked      = demae.NewSentryError("Please link your Just Eat Account with\nyour WiiLink Account", false)
+	ErrInvalidCountry = demae.NewSentryError("Your Wii's country does not support\nJust Eat", false)
 )

--- a/justeat/errors.go
+++ b/justeat/errors.go
@@ -1,8 +1,10 @@
 package justeat
 
-import "errors"
+import (
+	"github.com/WiiLink24/DemaeJustEat/demae"
+)
 
 var (
-	ErrNotLinked      = errors.New("please link your Just Eat Account with\nyour WiiLink Account")
-	ErrInvalidCountry = errors.New("your Wii's country does not support\nJust Eat")
+	ErrNotLinked      = demae.NewSentryError("Please link your Just Eat Account with\nyour WiiLink Account")
+	ErrInvalidCountry = demae.NewSentryError("Your Wii's country does not support\nJust Eat")
 )

--- a/justeat/errors.go
+++ b/justeat/errors.go
@@ -5,6 +5,6 @@ import (
 )
 
 var (
-	ErrNotLinked      = demae.NewSentryError("Please link your Just Eat Account with\nyour WiiLink Account", false)
+	ErrNotLinked      = demae.NewSentryError("Please link your Just Eat Account with\nyour WiiLink Account. Follow the guide\nat https://wiilink.ca/guide/just-eat", false)
 	ErrInvalidCountry = demae.NewSentryError("Your Wii's country does not support\nJust Eat", false)
 )

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -182,17 +183,21 @@ func PostDiscordWebhook(title, message, url string, color int) {
 // ReportError helps make errors nicer. First it logs the error to Sentry,
 // then writes a response for the server to send.
 func (r *Response) ReportError(err error) {
-	if hub := sentry.GetHubFromContext(r.request.Context()); hub != nil {
-		hub.WithScope(func(s *sentry.Scope) {
-			s.SetTag("Wii ID", r.GetHollywoodId())
-			hub.CaptureException(err)
-		})
+	// Only report errors that can be up-casted to SentryError
+	_, ok := errors.AsType[*demae.SentryError](err)
+	if ok {
+		if hub := sentry.GetHubFromContext(r.request.Context()); hub != nil {
+			hub.WithScope(func(s *sentry.Scope) {
+				s.SetTag("Wii ID", r.GetHollywoodId())
+				hub.CaptureException(err)
+			})
+		}
+
+		log.Printf("An error has occurred: %s", aurora.Red(err.Error()))
+
+		errorString := fmt.Sprintf("%s\nWii ID: %s\nWii Number: %s", err.Error(), r.GetHollywoodId(), r.request.Header.Get("X-WiiNo"))
+		PostDiscordWebhook("An error has occurred in Demae Just Eat!", errorString, config.ErrorWebhook, 16711711)
 	}
-
-	log.Printf("An error has occurred: %s", aurora.Red(err.Error()))
-
-	errorString := fmt.Sprintf("%s\nWii ID: %s\nWii Number: %s", err.Error(), r.GetHollywoodId(), r.request.Header.Get("X-WiiNo"))
-	PostDiscordWebhook("An error has occurred in Demae Just Eat!", errorString, config.ErrorWebhook, 16711711)
 
 	// With the new patches I created, we can now send the error to the channel.
 	r.AddKVNode("error", err.Error())

--- a/utils.go
+++ b/utils.go
@@ -184,8 +184,8 @@ func PostDiscordWebhook(title, message, url string, color int) {
 // then writes a response for the server to send.
 func (r *Response) ReportError(err error) {
 	// Only report errors that can be up-casted to SentryError
-	_, ok := errors.AsType[*demae.SentryError](err)
-	if ok {
+	e, ok := errors.AsType[*demae.SentryError](err)
+	if ok && e.Report {
 		if hub := sentry.GetHubFromContext(r.request.Context()); hub != nil {
 			hub.WithScope(func(s *sentry.Scope) {
 				s.SetTag("Wii ID", r.GetHollywoodId())

--- a/utils.go
+++ b/utils.go
@@ -183,9 +183,9 @@ func PostDiscordWebhook(title, message, url string, color int) {
 // ReportError helps make errors nicer. First it logs the error to Sentry,
 // then writes a response for the server to send.
 func (r *Response) ReportError(err error) {
-	// Only report errors that can be up-casted to SentryError
+	// Cast up to SentryError if possible otherwise report if a generic error.
 	e, ok := errors.AsType[*demae.SentryError](err)
-	if ok && e.Report {
+	if (ok && e.Report) || !ok {
 		if hub := sentry.GetHubFromContext(r.request.Context()); hub != nil {
 			hub.WithScope(func(s *sentry.Scope) {
 				s.SetTag("Wii ID", r.GetHollywoodId())


### PR DESCRIPTION
Go 1.26 introduced `errors.AsType`. This allows us to cast the error to a different type if possible. Previously, `error.As` existed, however it would panic if the type is not guaranteed to be the one casted.

Utilizing this principle, I have introduced the `SentryError` type. It is a structure that implements error which can be used to either report or not report certain errors. Its type is checked in the ReportError function. Errors that are not `SentryError` will still be reported as they are probably some HTTP or database error we need to see.