### PR TITLE
Fix floating point issue on total and correct total amount calculation

### DIFF
--- a/demae/utils.go
+++ b/demae/utils.go
@@ -59,6 +59,13 @@ func FloatToString(f float64) string {
 	return strconv.FormatFloat(f, 'g', -1, 64)
 }
 
+func FormatDecimal(f float64, precision int) string {
+	formatted := strconv.FormatFloat(f, 'f', precision, 64)
+	formatted = strings.TrimRight(formatted, "0")
+	formatted = strings.TrimRight(formatted, ".")
+	return formatted
+}
+
 func UUID() string {
 	u, _ := uuid.NewUUID()
 	return u.String()

--- a/justeat/order.go
+++ b/justeat/order.go
@@ -26,7 +26,7 @@ func (j *JEClient) PlaceOrder(r *http.Request, basketId string) error {
 			UnitAmount: demae.FloatToString(item.UnitPrice),
 		})
 
-		paymentTotal += item.UnitPrice
+		paymentTotal += float64(item.Quantity) * item.UnitPrice
 	}
 
 	// Deals
@@ -38,7 +38,7 @@ func (j *JEClient) PlaceOrder(r *http.Request, basketId string) error {
 			UnitAmount: demae.FloatToString(deal.UnitPrice),
 		})
 
-		paymentTotal += deal.UnitPrice
+		paymentTotal += float64(deal.Quantity) * deal.UnitPrice
 	}
 
 	// Per giustino:

--- a/justeat/server/server.go
+++ b/justeat/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"text/template"
 
 	"github.com/WiiLink24/DemaeJustEat/demae"
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -60,6 +61,9 @@ func RunServer(config *demae.Config) {
 	}
 
 	r := gin.Default()
+	r.SetFuncMap(template.FuncMap{
+		"formatDecimal": demae.FormatDecimal,
+	})
 	r.LoadHTMLGlob("./justeat/templates/*")
 
 	r.GET("/", func(c *gin.Context) {

--- a/justeat/templates/pay.html
+++ b/justeat/templates/pay.html
@@ -23,7 +23,7 @@
                         {{ $formattedWiiNumber := printf "%s-%s-%s-%s" (slice $order.WiiNumber 0 4) (slice
                         $order.WiiNumber 4 8) (slice $order.WiiNumber 8 12) (slice $order.WiiNumber 12 16) }}
                         <option value="{{ $order.WiiNumber }}">{{
-                            $order.Basket.Total }}{{ $order.Basket.CurrencyISOCode }} ({{
+                            $order.Basket.Total | formatDecimal 2 }}{{ $order.Basket.CurrencyISOCode }} ({{
                             $formattedWiiNumber }})</option>
                         {{ end }}
                     </select>
@@ -41,7 +41,7 @@
                                             <span class="text-gray-400 mr-2">{{ $item.Quantity }}x</span>
                                             <span class="text-gray-200">{{ $item.Name }}</span>
                                         </div>
-                                        <span class="w-32 text-right text-white font-medium">{{ $item.UnitAmount
+                                        <span class="w-32 text-right text-white font-medium">{{ $item.UnitAmount | formatDecimal 2 }}
                                             }} {{
                                             $order.Basket.CurrencyISOCode }}</span>
                                     </div>
@@ -63,7 +63,7 @@
                                 <div class="flex justify-between items-center">
                                     <span class="text-gray-300 text-lg">Total</span>
                                     <span class="text-white font-bold text-2xl">{{
-                                        $order.Basket.Total }} <span class="text-lg font-medium">{{
+                                        $order.Basket.Total | formatDecimal 2 }} <span class="text-lg font-medium">{{
                                             $order.Basket.CurrencyISOCode }}</span></span>
                                 </div>
                             </div>
@@ -135,7 +135,7 @@
                                         <div class="flex justify-between items-center">
                                             <span class="text-gray-300 text-lg">Total</span>
                                             <span class="text-white font-bold text-2xl">{{
-                                                $order.Basket.Total }} <span
+                                                $order.Basket.Total | formatDecimal 2 }} <span
                                                     class="text-lg font-medium">{{
                                                     $order.Basket.CurrencyISOCode }}</span></span>
                                         </div>


### PR DESCRIPTION
Added a formatDecimal function that will only include the last 2 decimals into the total inside the template, also corrected an issue where item quantity didn't multiply the unitPrice, making the total in the payment page inaccurate.