### PR TITLE
fix: use 32 char, 3 line wordwrap for item modifiers

### DIFF
--- a/justeat/menu.go
+++ b/justeat/menu.go
@@ -628,7 +628,7 @@ func (j *JEClient) GetItemModifiersForDeal(items *Items, variation Variation, mo
 						modifierList = append(modifierList, &demae.Item{
 							MenuCode:  demae.CDATA{Value: group.Id},
 							ItemCode:  demae.CDATA{Value: modifierId},
-							Name:      demae.CDATA{Value: demae.Wordwrap(item.Name, 18, 2)},
+							Name:      demae.CDATA{Value: demae.Wordwrap(item.Name, 32, 3)},
 							Price:     demae.CDATA{Value: dealItemVar.AdditionPrice},
 							Info:      demae.CDATA{Value: "None yet"},
 							Size:      nil,
@@ -720,7 +720,7 @@ func (j *JEClient) GetItemModifiers(variation Variation, modifiers *Modifiers) (
 						modifierList = append(modifierList, &demae.Item{
 							MenuCode:  demae.CDATA{Value: groupId},
 							ItemCode:  demae.CDATA{Value: modifierId},
-							Name:      demae.CDATA{Value: demae.Wordwrap(set.Modifier.Name, 18, 2)},
+							Name:      demae.CDATA{Value: demae.Wordwrap(set.Modifier.Name, 32, 3)},
 							Price:     demae.CDATA{Value: set.Modifier.AdditionPrice},
 							Info:      demae.CDATA{Value: "None yet"},
 							Size:      nil,
@@ -783,7 +783,7 @@ func (j *JEClient) GetItemModifiers(variation Variation, modifiers *Modifiers) (
 						parent.List.Value = append(parent.List.Value, demae.Item{
 							MenuCode:  demae.CDATA{Value: groupId},
 							ItemCode:  demae.CDATA{Value: modifierId},
-							Name:      demae.CDATA{Value: demae.Wordwrap(set.Modifier.Name, 18, 2)},
+							Name:      demae.CDATA{Value: demae.Wordwrap(set.Modifier.Name, 32, 3)},
 							Price:     demae.CDATA{Value: set.Modifier.AdditionPrice},
 							Info:      demae.CDATA{Value: "None yet"},
 							Size:      nil,


### PR DESCRIPTION
Previous wordwrap was too tight, making certain offers unusable:
<img width="2466" height="1383" alt="image" src="https://github.com/user-attachments/assets/9b84d2fd-3acd-43bc-904a-eefbecb63577" />
Now, there is enough length for the full offer to be visible:
<img width="1588" height="906" alt="image" src="https://github.com/user-attachments/assets/7e115465-2c5b-4723-a984-2271c61890ec" />
