### PR TITLE
fix: Map all German and Austrian cuisine tags to categories

### DIFF
--- a/justeat/categories.go
+++ b/justeat/categories.go
@@ -3,13 +3,13 @@ package justeat
 import "github.com/WiiLink24/DemaeJustEat/demae"
 
 var categoryTypes = map[demae.CategoryCode][]string{
-	demae.Pizza:            {"pizza", "italian-style-pizza"},
-	demae.Western:          {"hamburger", "pollo", "americano", "messicano", "american", "sandwiches", "burger", "amerikanisches-essen"},
-	demae.FastFood:         {"panini", "hamburger", "friti", "pollo", "chicken", "burger", "gefluegelgerichte", "doener"},
-	demae.Chinese:          {"cinese", "asianfusion", "asian", "chinese", "asiatisch-essen"},
-	demae.DrinksAndDessert: {"dolci", "gelato", "bevande", "desserts", "coffee", "cakes", "drinks", "getraenke-und-snacks", "snacks"},
-	demae.Curry:            {"curry", "indian", "indian-food"},
-	demae.Japanese:         {"asianfusion", "ramen", "japanese"},
-	demae.PartyFood:        {"kebab", "doener"},
+	demae.Pizza:            {"pizza", "italian-style-pizza", "italienische-pizza", "amerikanische-pizza", "tuerkische-pizza", "pide", "pinsa", "flammkuchen"},
+	demae.Western:          {"hamburger", "pollo", "americano", "messicano", "american", "sandwiches", "burger", "amerikanisches-essen", "italienisch", "italian-food", "pasta", "nudeln", "deutsches-essen", "deutsche-gerichte", "hausmannskost", "oesterreichische-kuche", "schnitzel", "griechisches-essen", "spanisch-und-tapas", "franzoesisches-essen", "portugiesisch-essen", "balkan", "polnisches-essen", "russisches-essen", "ukrainisches-essen", "mexikanisch", "lateinamerikanisch", "argentinisch-essen", "brasilianisch-essen", "steaks", "spare-ribs", "grillgerichte", "rindfleisch", "schweinefleisch", "kalb", "fisch", "meeresfruchte-essen", "suppen", "mittagessen", "internationales-essen", "sonstiges-essen", "fine_dining", "vegetarisches-essen", "vegan", "vegan-essen", "bioessen", "glutenfreies-essen"},
+	demae.FastFood:         {"panini", "hamburger", "friti", "pollo", "chicken", "burger", "gefluegelgerichte", "doener", "pommes", "hot-dog", "wraps", "bagels", "franzosische-tacos", "haehnchen", "salat", "bowls"},
+	demae.Chinese:          {"cinese", "asianfusion", "asian", "chinese", "asiatisch-essen", "chinesisch", "chinese-food", "sichuan", "dumplings", "fruhlingsrollen", "vietnamesisch", "thailaendisch", "indonesisches-essen", "koreanisches-essen", "koreanisch-essen"},
+	demae.DrinksAndDessert: {"dolci", "gelato", "bevande", "desserts", "coffee", "cakes", "drinks", "getraenke-und-snacks", "snacks", "eiscreme", "torte", "donuts", "backwaren", "pfannkuchen", "bubble_tea", "alkohol", "bei-cafes", "fruehstueck"},
+	demae.Curry:            {"curry", "indian", "indian-food", "indisch", "pakistanisches-essen", "afghanisch-essen", "persisches-essen"},
+	demae.Japanese:         {"asianfusion", "ramen", "japanese", "japanisches-essen", "poke-bowl"},
+	demae.PartyFood:        {"kebab", "doener", "tuerkisches-essen", "arabisches-essen", "libanesisches-essen", "syrische-gerichte", "israelisches-essen", "marokkanisches-essen", "afrikanisches-essen", "orientalisch", "falafel", "gyros", "100-prozent-halal", "halal", "koscher"},
 	demae.Sushi:            {"sushi"},
 }


### PR DESCRIPTION
`categoryTypes` only covered a handful of cuisine slugs. Just Eat localises them per tenant, so DE/AT slugs like `italienische-pizza`
or `japanisches-essen` were never matched and those restaurants stayed invisible.

This maps every cuisine slug returned by the DE and AT discovery endpoints, excluding
promotional tags and non-restaurant partners (groceries, shops, pharmacies).

Verified against live responses: uncategorised restaurants drop from 26 to 6 for my city and from 468 to 54 in Berlin; `Japanese` goes from empty to 12 and 68. (The remainder are supermarkets and pharmacies with no cuisine tag)