### PR TITLE
fix: Skip non-delivery restaurants instead of breaking the loop

### DIFF
--- a/justeat/restaurants.go
+++ b/justeat/restaurants.go
@@ -144,8 +144,9 @@ func (j *JEClient) GetRestaurants(code demae.CategoryCode) ([]demae.BasicShop, e
 			continue
 		}
 
+		// Skip restaurants that do not deliver
 		if !restaurant.(map[string]any)["isDelivery"].(bool) {
-			break
+			continue
 		}
 
 		// Store minimum delivery price in the cache.


### PR DESCRIPTION
`GetRestaurants` used `break` when a restaurant doesn't deliver, which stops the whole loop instead of just skipping that one. Everything after it in the categorywas dropped.

`continue` still keeps those restaurants out of the list, it just doesn't stop the scan
