### PR TITLE
feat: Raise restaurant cap and fix the field length crash

### DIFF
--- a/demae/field.go
+++ b/demae/field.go
@@ -13,18 +13,21 @@ import (
 // See PR for the disassembly
 const MaxFieldBytes = 127
 
+// Show ellipse for better UX. "…" is 3 bytes in UTF-8, same as "...": 127 - 3 = 124 bytes left for content.
+const ellipsis = "…"
+
 // TruncateField cuts s down to MaxFieldBytes, on a rune boundary.
 func TruncateField(s string) string {
 	if len(s) <= MaxFieldBytes {
 		return s
 	}
 
-	cut := MaxFieldBytes
+	cut := MaxFieldBytes - len(ellipsis)
 	for cut > 0 && !utf8.RuneStart(s[cut]) {
 		cut--
 	}
 
-	return s[:cut]
+	return s[:cut] + ellipsis
 }
 
 // MarshalXML writes the value as CDATA and truncates it on the way out.

--- a/demae/field.go
+++ b/demae/field.go
@@ -1,0 +1,42 @@
+package demae
+
+import (
+	"encoding/xml"
+	"unicode/utf8"
+)
+
+// MaxFieldBytes is the longest value the channel will read out of an XML node.
+// Up to 127 bytes plus the terminator uses a 128 byte stack buffer, anything
+// longer goes through a heap alloc, it never null checks and it fails with an
+// error screen. Tested on Wii hardware, 127 renders and 128 doesn't.
+//
+// See PR for the disassembly
+const MaxFieldBytes = 127
+
+// TruncateField cuts s down to MaxFieldBytes, on a rune boundary.
+func TruncateField(s string) string {
+	if len(s) <= MaxFieldBytes {
+		return s
+	}
+
+	cut := MaxFieldBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+
+	return s[:cut]
+}
+
+// MarshalXML writes the value as CDATA and truncates it on the way out.
+func (c CDATA) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	value := c.Value
+	if s, ok := value.(string); ok {
+		value = TruncateField(s)
+	}
+
+	type cdata struct {
+		Value any `xml:",cdata"`
+	}
+
+	return e.EncodeElement(cdata{Value: value}, start)
+}

--- a/demae/field_test.go
+++ b/demae/field_test.go
@@ -1,0 +1,68 @@
+package demae
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateField(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"under the limit", strings.Repeat("a", 100), 100},
+		{"exactly at the limit", strings.Repeat("a", MaxFieldBytes), MaxFieldBytes},
+		{"one over", strings.Repeat("a", MaxFieldBytes+1), MaxFieldBytes},
+		{"empty", "", 0},
+		{"umlauts", strings.Repeat("ä", 100), MaxFieldBytes - 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateField(tt.in)
+
+			if len(got) != tt.want {
+				t.Errorf("Expected %d bytes but got %d", tt.want, len(got))
+			}
+
+			if !utf8.ValidString(got) {
+				t.Errorf("Expected valid UTF-8 but got %q", got)
+			}
+		})
+	}
+}
+
+func TestCDATAMarshal(t *testing.T) {
+	type field struct {
+		XMLName xml.Name `xml:"shop"`
+		Value   CDATA    `xml:"name"`
+	}
+
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"short string", "Call a Pizza", "<![CDATA[Call a Pizza]]>"},
+		{"integer", 1500, "<![CDATA[1500]]>"},
+		{"float", 12.5, "<![CDATA[12.5]]>"},
+		{"empty", "", "<name></name>"},
+		{"too long", strings.Repeat("x", 500), "<![CDATA[" + strings.Repeat("x", MaxFieldBytes) + "]]>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := xml.Marshal(field{Value: CDATA{Value: tt.value}})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			if !strings.Contains(string(out), tt.want) {
+				t.Errorf("Expected %s but got %s", tt.want, out)
+			}
+		})
+	}
+}

--- a/demae/field_test.go
+++ b/demae/field_test.go
@@ -17,7 +17,7 @@ func TestTruncateField(t *testing.T) {
 		{"exactly at the limit", strings.Repeat("a", MaxFieldBytes), MaxFieldBytes},
 		{"one over", strings.Repeat("a", MaxFieldBytes+1), MaxFieldBytes},
 		{"empty", "", 0},
-		{"umlauts", strings.Repeat("ä", 100), MaxFieldBytes - 1},
+		{"umlauts", strings.Repeat("ä", 100), MaxFieldBytes},
 	}
 
 	for _, tt := range tests {
@@ -30,6 +30,26 @@ func TestTruncateField(t *testing.T) {
 
 			if !utf8.ValidString(got) {
 				t.Errorf("Expected valid UTF-8 but got %q", got)
+			}
+		})
+	}
+}
+
+func TestTruncateFieldEllipsis(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"under the limit", strings.Repeat("a", 100), false},
+		{"exactly at the limit", strings.Repeat("a", MaxFieldBytes), false},
+		{"over the limit", strings.Repeat("a", MaxFieldBytes+1), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := strings.HasSuffix(TruncateField(tt.in), ellipsis); got != tt.want {
+				t.Errorf("Expected %v but got %v", tt.want, got)
 			}
 		})
 	}
@@ -50,7 +70,7 @@ func TestCDATAMarshal(t *testing.T) {
 		{"integer", 1500, "<![CDATA[1500]]>"},
 		{"float", 12.5, "<![CDATA[12.5]]>"},
 		{"empty", "", "<name></name>"},
-		{"too long", strings.Repeat("x", 500), "<![CDATA[" + strings.Repeat("x", MaxFieldBytes) + "]]>"},
+		{"too long", strings.Repeat("x", 500), "<![CDATA[" + strings.Repeat("x", MaxFieldBytes-len(ellipsis)) + ellipsis + "]]>"},
 	}
 
 	for _, tt := range tests {

--- a/demae/remove_invalid_chars_test.go
+++ b/demae/remove_invalid_chars_test.go
@@ -11,3 +11,25 @@ func TestRemoveInvalidCharacters(t *testing.T) {
 		t.Error("incorrect result")
 	}
 }
+
+func TestRemoveInvalidCharactersLeadingEmoji(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"two leading emoji", "🍕🍕 Pizza", " Pizza"},
+		{"one leading emoji", "🍕 Pizza", " Pizza"},
+		{"only emoji", "🍕🍕🍕", ""},
+		{"emoji then text", "🍕Pizzeria", "Pizzeria"},
+		{"emoji in the middle", "Pizza 🍕 Napoli", "Pizza Napoli"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveInvalidCharacters(tt.in); got != tt.want {
+				t.Errorf("Expected %q but got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/demae/utils.go
+++ b/demae/utils.go
@@ -24,13 +24,13 @@ func BoolToInt(b bool) int {
 func RemoveInvalidCharacters(input string) string {
 	result := make([]rune, 0, len(input))
 
-	for i, r := range input {
+	for _, r := range input {
 		// Keep only printable ASCII and some specific Unicode ranges
 		if r < 128 || unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSpace(r) {
 			result = append(result, r)
 		} else {
 			// If it was invalid and the previous char was a space, we want to pop it.
-			if i == 0 {
+			if len(result) == 0 {
 				continue
 			}
 

--- a/justeat/constants.go
+++ b/justeat/constants.go
@@ -7,8 +7,9 @@ const (
 	InsertUser      = `INSERT INTO users (authentication, expires_at, refresh_token, acr, device_model, email, wii_id) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (wii_id) DO UPDATE SET authentication = EXCLUDED.authentication, expires_at = EXCLUDED.expires_at, refresh_token = EXCLUDED.refresh_token, acr = EXCLUDED.acr, device_model = EXCLUDED.device_model, email = EXCLUDED.email`
 )
 
-// MaxNumberOfRestaurants is required due to Wii memory constraints.
-const MaxNumberOfRestaurants = 15
+// MaxNumberOfRestaurants caps how many restaurants are returned per category.
+// The channel imposes no limit of its own
+const MaxNumberOfRestaurants = 50
 
 // Country is one that is supported by Just Eat
 type Country string


### PR DESCRIPTION
The comment said this was required due to Wii memory constraints, but I couldn't find anything backing that up, so I went looking.

I pulled the DOL out of the Food-Channel WAD from the WiiLinkPatcher and looked at the shop list parser myself. I couldn't find any limit in there. The loop bound is `GetChildCount(<ShopList>)`, so it reads as many `<Shop>` nodes as you send it. I went through every comparison in that function, they're all null checks.

Also, the `food-server` never had a limit at all, `get_restaurant()` just returned `.all()`.

`0x80038514` asks the XML how many shops there are and keeps that as the bound:

```
bl    0x800c4af4      ; GetChildCount(<ShopList>)
mr    r30, r3         ; r30 = node count
li    r23, 0          ; i = 0
```

`0x80038f28` at the end of the loop counts up to it:

```
addi  r23, r23, 1     ; i++
cmpw  r23, r30        ; i vs. node count from the XML
blt   0x80038528      ; loop
```

`0x800bf138` puts every shop into a linked list; 156 bytes per shop. The malloc return is checked too, so there's no fixed array to overflow, and if it ever does run out of memory it takes the failure path instead of writing past anything. The worst case you can get is an error screen. :

```
li    r3, 156         ; node size
bl    0x80022a50      ; allocate
cmpwi r3, 0           ; NULL check
beq   0x800bf150      ; -> failure path
```

I tested it on a real Wii with a small test server serving 50 shops in one category. Rendered and scrolled fine, no crashes/exceptions/lags found here.

Going with 50 rather than dropping the cap entirely, because `shopInfo` calls `GetRestaurants` once per category and each call refetches the whole discovery response and pulls logos one by one.

Happy to share the full writeup with the addresses and disassembly if anyone wants to check it :)